### PR TITLE
osu-lazer: fix `file not found` error

### DIFF
--- a/bucket/osu-lazer.json
+++ b/bucket/osu-lazer.json
@@ -15,8 +15,5 @@
             "osu!.exe",
             "Osu!Lazer"
         ]
-    ],
-    "installer": {
-        "file": "install"
-    }
+    ]
 }


### PR DESCRIPTION
```
~ scoop install osu-lazer
Installing 'osu-lazer' (2019.608.0) [64bit]
Loading osulazer-2019.608.0-full.nupkg from cache
Checking hash of osulazer-2019.608.0-full.nupkg ... ok.
Extracting dl.7z ... done.
Running installer... System.InvalidOperationException: Cannot run the command due to the following error: The system could not find the specified file.
   at System.Management.Automation.MshCommandRuntime.ThrowTerminatingError(ErrorRecord errorRecord)
Installation aborted. You might need to run 'scoop uninstall osu-lazer' before trying again.
```

Well, I don't really know if an installer is needed...